### PR TITLE
only download tatara if it does not exist

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,5 @@
 *-debug.log
 *-error.log
-heroku-cli-plugin-local-build-v*.tgz
 /.nyc_output
 /dist
 /lib

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 *-debug.log
 *-error.log
+heroku-cli-plugin-local-build-v*.tgz
 /.nyc_output
 /dist
 /lib

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,5 +4,5 @@ dist: trusty
 node_js:
 - '9.11.1'
 before_install: bash bin/ci
-script: bash bin/test
+script: yarn test
 after_script: heroku keys:remove $USER@`hostname`

--- a/package.json
+++ b/package.json
@@ -46,6 +46,9 @@
     "oclif-plugin"
   ],
   "license": "MIT",
+  "tatara": {
+    "version": "0.1.7"
+  },
   "oclif": {
     "commands": "./lib/commands",
     "bin": "oclif-example",
@@ -55,7 +58,7 @@
   },
   "repository": "heroku/plugin-local-build",
   "scripts": {
-    "postinstall": "node scripts/download.js 0.1.7",
+    "postinstall": "node scripts/download.js",
     "postpack": "rm -f oclif.manifest.json",
     "prepack": "rm -rf lib && tsc && oclif-dev manifest && oclif-dev readme",
     "prepare": "rm -rf lib && tsc",

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "@oclif/config": "^1",
     "@types/debug": "^0.0.30",
     "@types/shell-escape": "^0.2.0",
+    "cli-ux": "^4.6.3",
     "debug": "^3.1.0",
     "node-fetch": "^2.1.2",
     "tslib": "^1"
@@ -58,7 +59,8 @@
     "postpack": "rm -f oclif.manifest.json",
     "prepack": "rm -rf lib && tsc && oclif-dev manifest && oclif-dev readme",
     "prepare": "rm -rf lib && tsc",
-    "test": "nyc mocha --forbid-only \"test/**/*.test.ts\"",
+    "test": "bash bin/test && nyc mocha --forbid-only \"test/**/*.test.ts\"",
+    "posttest": "tslint -p .",
     "version": "oclif-dev readme && git add README.md"
   }
 }

--- a/scripts/download.js
+++ b/scripts/download.js
@@ -30,13 +30,15 @@ async function download(url, file, callback) {
 
 
 const extension = getExtension();
-const version = process.argv[2];
-const file = `bin/tatara-${extension}`;
+const version = require('../package.json').tatara.version;
+const file = `bin/tatara-${version}-${extension}`;
 const url = `https://github.com/heroku/tatara/releases/download/v${version}/tatara-${version}-${extension}`;
 
 if (!fs.existsSync('bin')) fs.mkdirSync('bin');
 
-console.log(`Downloading ${file} from ${url}`)
-download(url, file, () => {
-  fs.chmodSync(file, 0o765);
-});
+if (!fs.existsSync(file)) {
+  console.log(`Downloading ${file} from ${url}`)
+  download(url, file, () => {
+    fs.chmodSync(file, 0o765);
+  });
+}

--- a/src/commands/local/build.ts
+++ b/src/commands/local/build.ts
@@ -7,7 +7,7 @@ import * as debug from 'debug'
 
 import {Tatara} from '../../tatara'
 
-const child = require('child_process');
+const child = require('child_process')
 
 export default class Build extends Command {
   static description = 'Build an app locally'
@@ -21,7 +21,7 @@ $ heroku local:build`,
     config: flags.boolean()
   }
 
-  async run () {
+  async run() {
     const {flags} = this.parse(Build)
 
     let bin = (new Tatara(process.platform).path())
@@ -31,17 +31,15 @@ $ heroku local:build`,
       cmdArgs.push('--skip-stack-pull')
     }
 
-    let envVars
     if (flags.config) {
       let envVars = await this.heroku.get<Heroku.App>(`/apps/${flags.app}/config-vars`)
-      for (var name in envVars.body) {
-        let value = envVars.body[name]
-        cmdArgs.push(`--env=${name}=${value}`)
+      for (let [k, v] of Object.entries(envVars.body)) {
+        cmdArgs.push(`--env=${k}=${v}`)
       }
     }
 
     if (debug('local:build').enabled) {
-      cmdArgs.push(`--debug`)
+      cmdArgs.push('--debug')
     }
 
     cli.debug(`Executing ${bin}`)
@@ -52,12 +50,12 @@ $ heroku local:build`,
       })
       .on('close', (code: any) => {
         if (code) this.error(`Failed to build ${flags.app}`)
-      });
+      })
     spawned.stdout.on('data', (chunk: any) => {
-      process.stdout.write(chunk.toString());
-    });
+      process.stdout.write(chunk.toString())
+    })
     spawned.stderr.on('data', (chunk: any) => {
-      process.stderr.write(chunk.toString());
-    });
+      process.stderr.write(chunk.toString())
+    })
   }
 }

--- a/src/commands/local/export.ts
+++ b/src/commands/local/export.ts
@@ -1,12 +1,11 @@
 // note that we are using @heroku-cli/command instead of @oclif/command
 // this inherits from @oclif/command but extends it with Heroku-specific functionality
 import {Command, flags} from '@heroku-cli/command'
-import * as Heroku from '@heroku-cli/schema'
 import {cli} from 'cli-ux'
 
 import {Tatara} from '../../tatara'
 
-const child = require('child_process');
+const child = require('child_process')
 
 export default class Export extends Command {
   static description = 'Export a build to a Docker image'
@@ -20,7 +19,7 @@ $ heroku local:export`,
     'skip-stack-pull': flags.boolean()
   }
 
-  async run () {
+  async run() {
     const {flags} = this.parse(Export)
 
     let bin = (new Tatara(process.platform)).path()
@@ -42,13 +41,13 @@ $ heroku local:export`,
         this.error(err)
       })
       .on('close', (code: any) => {
-        if (code) this.error(code);
-      });
+        if (code) this.error(code)
+      })
     spawned.stdout.on('data', (chunk: any) => {
-      process.stdout.write(chunk.toString());
-    });
+      process.stdout.write(chunk.toString())
+    })
     spawned.stderr.on('data', (chunk: any) => {
-      process.stderr.write(chunk.toString());
-    });
+      process.stderr.write(chunk.toString())
+    })
   }
 }

--- a/src/commands/local/run.ts
+++ b/src/commands/local/run.ts
@@ -7,7 +7,7 @@ import * as debug from 'debug'
 
 import {Tatara} from '../../tatara'
 
-const child = require('child_process');
+const child = require('child_process')
 
 export default class Run extends Command {
   static description = 'Run a locally built app'
@@ -21,7 +21,7 @@ $ heroku local:run`,
     config: flags.boolean()
   }
 
-  async run () {
+  async run() {
     const {flags} = this.parse(Run)
 
     let bin = (new Tatara(process.platform)).path()
@@ -32,15 +32,13 @@ $ heroku local:run`,
     }
 
     if (debug('local:run').enabled) {
-      cmdArgs.push(`--debug`)
+      cmdArgs.push('--debug')
     }
 
-    let envVars
     if (flags.config) {
       let envVars = await this.heroku.get<Heroku.App>(`/apps/${flags.app}/config-vars`)
-      for (var name in envVars.body) {
-        let value = envVars.body[name]
-        cmdArgs.push(`--env=${name}=${value}`)
+      for (let [k, v] of Object.entries(envVars.body)) {
+        cmdArgs.push(`--env=${k}=${v}`)
       }
     }
 
@@ -50,13 +48,13 @@ $ heroku local:run`,
         this.error(err)
       })
       .on('close', (code: any) => {
-        if (code) this.error(code);
-      });
+        if (code) this.error(code)
+      })
     spawned.stdout.on('data', (chunk: any) => {
-      process.stdout.write(chunk.toString());
-    });
+      process.stdout.write(chunk.toString())
+    })
     spawned.stderr.on('data', (chunk: any) => {
-      process.stderr.write(chunk.toString());
-    });
+      process.stderr.write(chunk.toString())
+    })
   }
 }

--- a/src/tatara.ts
+++ b/src/tatara.ts
@@ -1,4 +1,5 @@
-const path = require('path')
+import * as path from 'path'
+const pjson = require('../package.json')
 
 export class Tatara {
   platform: string
@@ -10,11 +11,11 @@ export class Tatara {
   path(): string {
     let bin
     if (this.platform === 'win32') {
-      bin = path.join(__dirname, '..', 'bin', 'tatara-windows.exe')
+      bin = path.join(__dirname, '..', 'bin', `tatara-${pjson.tatara.version}-windows.exe`)
     } else if (this.platform === 'darwin') {
-      bin = path.join(__dirname, '..', 'bin', 'tatara-macos')
+      bin = path.join(__dirname, '..', 'bin', `tatara-${pjson.tatara.version}-macos`)
     } else if (this.platform === 'linux') {
-      bin = path.join(__dirname, '..', 'bin', 'tatara-linux')
+      bin = path.join(__dirname, '..', 'bin', `tatara-${pjson.tatara.version}-linux`)
     } else {
       throw new Error(`Unsupported platform: ${this.platform}`)
     }

--- a/src/tatara.ts
+++ b/src/tatara.ts
@@ -1,6 +1,4 @@
-import {cli} from 'cli-ux'
-
-const path = require('path');
+const path = require('path')
 
 export class Tatara {
   platform: string
@@ -12,11 +10,11 @@ export class Tatara {
   path(): string {
     let bin
     if (this.platform === 'win32') {
-      bin = path.join(__dirname, '..', 'bin', `tatara-windows.exe`)
+      bin = path.join(__dirname, '..', 'bin', 'tatara-windows.exe')
     } else if (this.platform === 'darwin') {
-      bin = path.join(__dirname, '..', 'bin', `tatara-macos`)
+      bin = path.join(__dirname, '..', 'bin', 'tatara-macos')
     } else if (this.platform === 'linux') {
-      bin = path.join(__dirname, '..', 'bin', `tatara-linux`)
+      bin = path.join(__dirname, '..', 'bin', 'tatara-linux')
     } else {
       throw new Error(`Unsupported platform: ${this.platform}`)
     }

--- a/yarn.lock
+++ b/yarn.lock
@@ -535,6 +535,28 @@ cli-ux@^4.6.0:
     supports-color "^5.4.0"
     supports-hyperlinks "^1.0.1"
 
+cli-ux@^4.6.3:
+  version "4.6.3"
+  resolved "https://registry.yarnpkg.com/cli-ux/-/cli-ux-4.6.3.tgz#cc47aff73deeb7dd9b0b86f136755768403060be"
+  dependencies:
+    "@oclif/linewrap" "^1.0.0"
+    "@oclif/screen" "^1.0.2"
+    ansi-styles "^3.2.1"
+    cardinal "^2.1.1"
+    chalk "^2.4.1"
+    clean-stack "^1.3.0"
+    extract-stack "^1.0.0"
+    fs-extra "^6.0.1"
+    hyperlinker "^1.0.0"
+    indent-string "^3.2.0"
+    is-wsl "^1.1.0"
+    lodash "^4.17.10"
+    password-prompt "^1.0.6"
+    semver "^5.5.0"
+    strip-ansi "^4.0.0"
+    supports-color "^5.4.0"
+    supports-hyperlinks "^1.0.1"
+
 cliui@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/cliui/-/cliui-2.1.0.tgz#4b475760ff80264c762c3a1719032e91c7fea0d1"


### PR DESCRIPTION
because reasons, the CLI will actually run this setup twice when it is first installed and again on every update. It seems we can just install it when the version is changed.

Depends on #7